### PR TITLE
Implement way to run pipeline commands locally in docker, starting with `fetch`

### DIFF
--- a/collection.mk
+++ b/collection.mk
@@ -59,3 +59,7 @@ load-resources::
 collection/resource/%:
 	@mkdir -p collection/resource/
 	curl -qfsL '$(DATASTORE_URL)$(REPOSITORY)/$(RESOURCE_DIR)$(notdir $@)' > $@
+
+# dev
+dockerised-fetch::
+	docker run -v $(PWD):/pipeline --workdir /pipeline digital_land_python digital-land fetch $(ENDPOINT_URL) --specification-dir=/collection/specification/

--- a/collection.mk
+++ b/collection.mk
@@ -16,19 +16,6 @@ ifeq ($(DATASTORE_URL),)
 DATASTORE_URL=https://collection-dataset.s3.eu-west-2.amazonaws.com/
 endif
 
-EXTRA_MOUNTS :=
-ifdef ($(LOCAL_SPECIFICATION_PATH),)
-	EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
-else ifeq ($(LOCAL_SPECIFICATION),1)
-	EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
-endif
-
-ifdef ($(LOCAL_DL_PYTHON_PATH),)
-	EXTRA_MOUNTS += -v $(LOCAL_DL_PYTHON_PATH):/Src
-else ifeq ($(LOCAL_DL_PYTHON),1)
-	EXTRA_MOUNTS += -v $(PWD)/../digital-land-python:/src"
-endif
-
 
 # data sources
 SOURCE_CSV=$(COLLECTION_DIR)source.csv
@@ -72,18 +59,3 @@ load-resources::
 collection/resource/%:
 	@mkdir -p collection/resource/
 	curl -qfsL '$(DATASTORE_URL)$(REPOSITORY)/$(RESOURCE_DIR)$(notdir $@)' > $@
-
-# dev
-dockerised-fetch::
-	mkdir -p local_collection
-	docker run -t \
-		-u $(shell id -u) \
-		-v $(PWD):/pipeline \
-		-v $(PWD)/local_collection:/data \
-		$(EXTRA_MOUNTS) \
-		--workdir /data \
-		$(ECR_URL)digital_land_python:$(DOCKER_TAG) \
-		digital-land \
-		--specification-dir /collection/specification \
-		fetch \
-		'$(ENDPOINT_URL)'

--- a/development.mk
+++ b/development.mk
@@ -17,7 +17,7 @@ else ifeq ($(LOCAL_DL_PYTHON),1)
 endif
 
 DOCKER_TAG=latest
-ECR_URL=
+ECR_URL=public.ecr.aws/l6z6v3j6/
 
 # useful when developing
 # export PIP_REQUIRE_VIRTUALENV=true
@@ -48,11 +48,16 @@ dockerised = docker run -t \
 	-v $(PWD)/local_collection:/data \
 	$(EXTRA_MOUNTS) \
 	--workdir /data \
-	$(ECR_URL)digital_land_python:$(DOCKER_TAG) \
+	$(ECR_URL)digital-land-python:$(DOCKER_TAG) \
 	digital-land \
 	--specification-dir /collection/specification
 
-dockerised-fetch::
+docker-pull::
+ifndef ($(DISABLE_DOCKER_PULL),)
+	docker pull $(ECR_URL)digital-land-python:$(DOCKER_TAG)
+endif
+
+dockerised-fetch:: docker-pull
 	mkdir -p local_collection
 	$(dockerised) \
 		fetch \

--- a/development.mk
+++ b/development.mk
@@ -43,7 +43,7 @@ makerules::
 	curl -qfsL '$(SOURCE_URL)/makerules/main/development.mk' > makerules/development.mk
 
 dockerised = docker run -t \
-	-u $(shell id -u) \
+	-e LOCAL_USER_ID=$(shell id -u) \
 	-v $(PWD):/pipeline \
 	-v $(PWD)/local_collection:/data \
 	$(EXTRA_MOUNTS) \

--- a/makerules.mk
+++ b/makerules.mk
@@ -86,7 +86,6 @@ prune::
 makerules::
 	curl -qfsL '$(SOURCE_URL)/makerules/main/makerules.mk' > makerules/makerules.mk
 
-ifeq (,$(wildcard ./makerules/specification.mk))
 # update local copies of specification files
 specification::
 	@mkdir -p specification/
@@ -101,6 +100,7 @@ specification::
 	curl -qfsL '$(SOURCE_URL)/specification/main/specification/pipeline.csv' > specification/pipeline.csv
 	curl -qfsL '$(SOURCE_URL)/specification/main/specification/theme.csv' > specification/theme.csv
 
+ifeq (,$(wildcard ./makerules/specification.mk))
 init::	specification
 endif
 

--- a/makerules.mk
+++ b/makerules.mk
@@ -58,6 +58,7 @@ second-pass::
 	@:
 
 # initialise
+ifeq (,$(wildcard /.dockerenv ))
 init::
 	pip install --upgrade pip
 ifneq (,$(wildcard requirements.txt))
@@ -65,6 +66,7 @@ ifneq (,$(wildcard requirements.txt))
 endif
 ifneq (,$(wildcard setup.py))
 	pip install -e .$(PIP_INSTALL_PACKAGE)
+endif
 endif
 
 submodules::


### PR DESCRIPTION
TLDR 
when you run this make command from a collection repo like so:
```
 make ENDPOINT_URL='<url goes here>' dockerised-fetch
```
It creates a local_collection folder within your collection repo and fetches the resource as the pipeline would, and puts the output in local_collection in the same format as the pipeline would.
Output:
```
mkdir -p local_collection

2022-01-07 17:47:55,997 INFO get https://maps.buckscc.gov.uk/arcgis/rest/services/PLANNING/RIPA_BOPS/MapServer/2/query?where=1%3D1&text=&objectIds=&time=&geometry=&geometryType=esriGeometryPolygon&inSR=&spatialRel=esriSpatialRelIntersects&relationParam=&outFields=*&returnGeometry=true&returnTrueCurves=false&maxAllowableOffset=&geometryPrecision=&outSR=&returnIdsOnly=false&returnCountOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&gdbVersion=&returnDistinctValues=false&resultOffset=&resultRecordCount=&f=geojson
2022-01-07 17:47:58,082 INFO collection/resource/e27ba5fb720eea44ad4d7f34a720d54303affc80faaa9e2874fe77dacfaf4b02
2022-01-07 17:47:58,085 INFO collection/log/2022-01-07/8ce86423c7426509901eb2dd87a0207f6b442c074a4336fe41b818dc02115242.json
```
Result:
```
> tree local_collection/
local_collection/
└── collection
    ├── log
    │   └── 2022-01-07
    │       └── 8ce86423c7426509901eb2dd87a0207f6b442c074a4336fe41b818dc02115242.json
    └── resource
        └── e27ba5fb720eea44ad4d7f34a720d54303affc80faaa9e2874fe77dacfaf4b02
```
Everything runs in docker so all the dependencies are taken care of (it will even pull the image once I set the ECR up)
This should help us debug issues with the pipeline in a much easier way.

TODO
* [ ] Check weird issue if fixed where `collection/pipeline.mk` is deleted when running against collection repo (specifically listed-building-collection)