### PR TITLE
Run all pipeline commands in docker (Proof of concept)

### DIFF
--- a/collection.mk
+++ b/collection.mk
@@ -37,10 +37,10 @@ first-pass:: collect
 second-pass:: collection
 
 collect:: $(SOURCE_CSV) $(ENDPOINT_CSV)
-	$(digital-land) collect $(ENDPOINT_CSV)
+	$(digital-land) collect $(ENDPOINT_CSV) --collection-dir $(COLLECTION_DIR)
 
 collection::
-	$(digital-land) collection-save-csv
+	$(digital-land) collection-save-csv  --collection-dir $(COLLECTION_DIR)
 
 clobber-today::
 	rm -rf $(LOG_FILES_TODAY) $(COLLECTION_INDEX)

--- a/collection.mk
+++ b/collection.mk
@@ -16,6 +16,45 @@ ifeq ($(DATASTORE_URL),)
 DATASTORE_URL=https://collection-dataset.s3.eu-west-2.amazonaws.com/
 endif
 
+ifeq ($(DOCKERISED),1)
+EXTRA_MOUNTS :=
+# Run in development mode by default for now
+ifneq ($(DEVELOPMENT),0)
+EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
+
+ifdef ($(LOCAL_SPECIFICATION_PATH),)
+	EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
+else ifeq ($(LOCAL_SPECIFICATION),1)
+	EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
+endif
+ifdef ($(LOCAL_DL_PYTHON_PATH),)
+	EXTRA_MOUNTS += -v $(LOCAL_DL_PYTHON_PATH):/Src
+else ifeq ($(LOCAL_DL_PYTHON),1)
+	EXTRA_MOUNTS += -v $(PWD)/../digital-land-python:/src
+endif
+endif
+
+DOCKER_TAG=latest
+ECR_URL=public.ecr.aws/l6z6v3j6/
+
+digital-land = docker run -t \
+	-u $(shell id -u) \
+	-v $(PWD):/pipeline \
+	$(EXTRA_MOUNTS) \
+	$(ECR_URL)digital-land-python:$(DOCKER_TAG) \
+	digital-land \
+	--specification-dir /collection/specification
+
+docker-pull::
+ifndef ($(DISABLE_DOCKER_PULL),)
+	docker pull $(ECR_URL)digital-land-python:$(DOCKER_TAG)
+endif
+
+init:: docker-pull
+else
+digital-land = digital-land
+endif
+
 
 # data sources
 SOURCE_CSV=$(COLLECTION_DIR)source.csv
@@ -35,10 +74,10 @@ first-pass:: collect
 second-pass:: collection
 
 collect:: $(SOURCE_CSV) $(ENDPOINT_CSV)
-	digital-land collect $(ENDPOINT_CSV)
+	$(digital-land) collect $(ENDPOINT_CSV)
 
 collection::
-	digital-land collection-save-csv
+	$(digital-land) collection-save-csv
 
 clobber-today::
 	rm -rf $(LOG_FILES_TODAY) $(COLLECTION_INDEX)
@@ -46,12 +85,21 @@ clobber-today::
 makerules::
 	curl -qfsL '$(SOURCE_URL)/makerules/main/collection.mk' > makerules/collection.mk
 
+# These will run as usual unless we're in a dockerised environment and DEVELOPMENT isn't explicitly set to 1
+ifneq ($(DOCKERISED),1)
+ifneq ($(DEVELOPMENT),1)
+commit-dataset::
+	mkdir -p $(DATASET_DIRS)
+	git add $(DATASET_DIRS)
+	git diff --quiet && git diff --staged --quiet || (git commit -m "Data $(shell date +%F)"; git push origin $(BRANCH))
+
 commit-collection::
 	git add collection
 	git diff --quiet && git diff --staged --quiet || (git commit -m "Collection $(shell date +%F)"; git push origin $(BRANCH))
 
 save-resources::
 	aws s3 sync s3://collection-dataset/$(REPOSITORY)/$(RESOURCE_DIR) $(RESOURCE_DIR)
+endif
 
 load-resources::
 	aws s3 sync $(RESOURCE_DIR) s3://collection-dataset/$(REPOSITORY)/$(RESOURCE_DIR)

--- a/collection.mk
+++ b/collection.mk
@@ -48,7 +48,7 @@ clobber-today::
 makerules::
 	curl -qfsL '$(SOURCE_URL)/makerules/main/collection.mk' > makerules/collection.mk
 
-# These will run as usual unless we're in a dockerised environment and DEVELOPMENT isn't explicitly set to 1 i.e if DEVELOPMENT != 1 or DOCKERISED != 1
+# These will run as usual if DEVELOPMENT isn't explicitly set to 1
 ifeq ($(DEVELOPMENT),0)
 commit-dataset::
 	mkdir -p $(DATASET_DIRS)

--- a/collection.mk
+++ b/collection.mk
@@ -16,22 +16,30 @@ ifeq ($(DATASTORE_URL),)
 DATASTORE_URL=https://collection-dataset.s3.eu-west-2.amazonaws.com/
 endif
 
-ifeq ($(DOCKERISED),1)
-EXTRA_MOUNTS :=
-# Run in development mode by default for now
-ifneq ($(DEVELOPMENT),0)
-EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
+ifndef ($(DOCKERISED),)
+	DOCKERISED = 0
+	DEVELOPMENT = 0
+else
+	# Run in development mode by default for now
+	ifndef ($(DEVELOPMENT),)
+		DEVELOPMENT = 1
+	endif
+endif
 
-ifdef ($(LOCAL_SPECIFICATION_PATH),)
-	EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
-else ifeq ($(LOCAL_SPECIFICATION),1)
-	EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
-endif
-ifdef ($(LOCAL_DL_PYTHON_PATH),)
-	EXTRA_MOUNTS += -v $(LOCAL_DL_PYTHON_PATH):/Src
-else ifeq ($(LOCAL_DL_PYTHON),1)
-	EXTRA_MOUNTS += -v $(PWD)/../digital-land-python:/src
-endif
+EXTRA_MOUNTS :=
+ifeq ($(and $(DOCKERISED),$(DEVELOPMENT)))
+	EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
+
+	ifdef ($(LOCAL_SPECIFICATION_PATH),)
+		EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
+	else ifeq ($(LOCAL_SPECIFICATION),1)
+		EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
+	endif
+	ifdef ($(LOCAL_DL_PYTHON_PATH),)
+		EXTRA_MOUNTS += -v $(LOCAL_DL_PYTHON_PATH):/Src
+	else ifeq ($(LOCAL_DL_PYTHON),1)
+		EXTRA_MOUNTS += -v $(PWD)/../digital-land-python:/src
+	endif
 endif
 
 DOCKER_TAG=latest
@@ -85,9 +93,8 @@ clobber-today::
 makerules::
 	curl -qfsL '$(SOURCE_URL)/makerules/main/collection.mk' > makerules/collection.mk
 
-# These will run as usual unless we're in a dockerised environment and DEVELOPMENT isn't explicitly set to 1
-ifneq ($(DOCKERISED),1)
-ifneq ($(DEVELOPMENT),1)
+# These will run as usual unless we're in a dockerised environment and DEVELOPMENT isn't explicitly set to 1 i.e if DEVELOPMENT != 1 or DOCKERISED != 1
+ifneq ($(and $(DOCKERISED),$(DEVELOPMENT)))
 commit-dataset::
 	mkdir -p $(DATASET_DIRS)
 	git add $(DATASET_DIRS)

--- a/collection.mk
+++ b/collection.mk
@@ -4,6 +4,8 @@
 	commit-collection\
 	clobber-today
 
+include makerules/docker.mk
+
 ifeq ($(COLLECTION_DIR),)
 COLLECTION_DIR=collection/
 endif
@@ -14,53 +16,6 @@ endif
 
 ifeq ($(DATASTORE_URL),)
 DATASTORE_URL=https://collection-dataset.s3.eu-west-2.amazonaws.com/
-endif
-
-ifndef ($(DOCKERISED),)
-	DOCKERISED = 0
-	DEVELOPMENT = 0
-else
-	# Run in development mode by default for now
-	ifndef ($(DEVELOPMENT),)
-		DEVELOPMENT = 1
-	endif
-endif
-
-EXTRA_MOUNTS :=
-ifeq ($(and $(DOCKERISED),$(DEVELOPMENT)))
-	EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
-
-	ifdef ($(LOCAL_SPECIFICATION_PATH),)
-		EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
-	else ifeq ($(LOCAL_SPECIFICATION),1)
-		EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
-	endif
-	ifdef ($(LOCAL_DL_PYTHON_PATH),)
-		EXTRA_MOUNTS += -v $(LOCAL_DL_PYTHON_PATH):/Src
-	else ifeq ($(LOCAL_DL_PYTHON),1)
-		EXTRA_MOUNTS += -v $(PWD)/../digital-land-python:/src
-	endif
-endif
-
-DOCKER_TAG=latest
-ECR_URL=public.ecr.aws/l6z6v3j6/
-
-digital-land = docker run -t \
-	-u $(shell id -u) \
-	-v $(PWD):/pipeline \
-	$(EXTRA_MOUNTS) \
-	$(ECR_URL)digital-land-python:$(DOCKER_TAG) \
-	digital-land \
-	--specification-dir /collection/specification
-
-docker-pull::
-ifndef ($(DISABLE_DOCKER_PULL),)
-	docker pull $(ECR_URL)digital-land-python:$(DOCKER_TAG)
-endif
-
-init:: docker-pull
-else
-digital-land = digital-land
 endif
 
 
@@ -94,7 +49,7 @@ makerules::
 	curl -qfsL '$(SOURCE_URL)/makerules/main/collection.mk' > makerules/collection.mk
 
 # These will run as usual unless we're in a dockerised environment and DEVELOPMENT isn't explicitly set to 1 i.e if DEVELOPMENT != 1 or DOCKERISED != 1
-ifneq ($(and $(DOCKERISED),$(DEVELOPMENT)))
+ifeq ($(DEVELOPMENT),0)
 commit-dataset::
 	mkdir -p $(DATASET_DIRS)
 	git add $(DATASET_DIRS)

--- a/docker.mk
+++ b/docker.mk
@@ -55,11 +55,22 @@ EXTRA_DL_ARGS += --specification-dir /collection/specification
 
 /pipeline/collection/endpoint.csv:
 
-digital-land = docker run -t \
+dockerised = docker run -t \
 	-e LOCAL_USER_ID=$(shell id -u) \
+	-e AWS_ACCESS_KEY_ID \
+    -e AWS_DEFAULT_REGION \
+    -e AWS_REGION \
+    -e AWS_SECRET_ACCESS_KEY \
+    -e AWS_SECURITY_TOKEN \
+    -e AWS_SESSION_EXPIRATION \
+    -e AWS_SESSION_TOKEN \
 	-v $(PWD):/pipeline \
 	$(EXTRA_MOUNTS) \
-	$(ECR_URL)digital-land-python:$(DOCKER_TAG) \
+	$(ECR_URL)digital-land-python:$(DOCKER_TAG)
+
+shell_cmd = $(dockerised) bash
+
+digital-land = $(dockerised) \
 	digital-land \
 	$(EXTRA_DL_ARGS)
 
@@ -70,6 +81,9 @@ endif
 
 init:: docker-pull
 else
+shell_cmd = $(SHELL)
 digital-land = digital-land
 endif
 
+debug_shell:
+	$(shell_cmd)

--- a/docker.mk
+++ b/docker.mk
@@ -1,0 +1,58 @@
+ifneq ($(DOCKERISED),1)
+DOCKERISED = 0
+DEVELOPMENT = 0
+else
+# Run in development mode by default for now
+ifeq ($(DEVELOPMENT),0)
+DEVELOPMENT = 0
+else
+DEVELOPMENT = 1
+endif
+endif
+$(info    DOCKERISED is $(DOCKERISED))
+$(info    DEVELOPMENT is $(DEVELOPMENT))
+
+EXTRA_MOUNTS :=
+# ifeq ($(and $(DOCKERISED),$(DEVELOPMENT)))
+ifeq ($(DOCKERISED),1)
+ifeq ($(DEVELOPMENT),1)
+EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
+
+ifdef ($(LOCAL_SPECIFICATION_PATH),)
+EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
+else ifeq ($(LOCAL_SPECIFICATION),1)
+EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
+endif
+
+ifdef ($(LOCAL_DL_PYTHON_PATH),)
+EXTRA_MOUNTS += -v $(LOCAL_DL_PYTHON_PATH):/Src
+else ifeq ($(LOCAL_DL_PYTHON),1)
+EXTRA_MOUNTS += -v $(PWD)/../digital-land-python:/src
+endif
+
+endif
+$(info    EXTRA_MOUNTS is $(EXTRA_MOUNTS))
+
+DOCKER_TAG=latest
+ECR_URL=public.ecr.aws/l6z6v3j6/
+
+COLLECTION_DIR=/pipeline/collection/
+
+digital-land = docker run -t \
+	-e LOCAL_USER_ID=$(shell id -u) \
+	-v $(PWD):/pipeline \
+	$(EXTRA_MOUNTS) \
+	$(ECR_URL)digital-land-python:$(DOCKER_TAG) \
+	digital-land \
+	--specification-dir /collection/specification
+
+docker-pull::
+ifndef ($(DISABLE_DOCKER_PULL),)
+	docker pull $(ECR_URL)digital-land-python:$(DOCKER_TAG)
+endif
+
+init:: docker-pull
+else
+digital-land = digital-land
+endif
+

--- a/docker.mk
+++ b/docker.mk
@@ -38,6 +38,12 @@ ECR_URL=public.ecr.aws/l6z6v3j6/
 
 COLLECTION_DIR=/pipeline/collection/
 
+/pipeline/collection/resource.csv:
+
+/pipeline/collection/source.csv:
+
+/pipeline/collection/endpoint.csv:
+
 digital-land = docker run -t \
 	-e LOCAL_USER_ID=$(shell id -u) \
 	-v $(PWD):/pipeline \

--- a/docker.mk
+++ b/docker.mk
@@ -21,7 +21,7 @@ EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
 ifdef ($(LOCAL_SPECIFICATION_PATH),)
 EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
 else ifeq ($(LOCAL_SPECIFICATION),1)
-EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
+EXTRA_MOUNTS += -v $(PWD)/../specification/specification:/collection/specification
 endif
 
 ifdef ($(LOCAL_DL_PYTHON_PATH),)

--- a/docker.mk
+++ b/docker.mk
@@ -13,10 +13,21 @@ $(info    DOCKERISED is $(DOCKERISED))
 $(info    DEVELOPMENT is $(DEVELOPMENT))
 
 EXTRA_MOUNTS :=
+EXTRA_DL_ARGS :=
 # ifeq ($(and $(DOCKERISED),$(DEVELOPMENT)))
 ifeq ($(DOCKERISED),1)
 ifeq ($(DEVELOPMENT),1)
-EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
+EXTRA_MOUNTS += -v $(PWD)/local_collection/collection/log:/pipeline/collection/log
+EXTRA_MOUNTS += -v $(PWD)/local_collection/collection/resource:/pipeline/collection/resource
+ifneq (,$(wildcard ./fixed))
+EXTRA_MOUNTS += -v $(PWD)/local_collection/fixed:/pipeline/fixed
+endif
+ifneq (,$(wildcard ./harmonised))
+EXTRA_MOUNTS += -v $(PWD)/local_collection/harmonised:/pipeline/harmonised
+endif
+ifneq (,$(wildcard ./harmonised))
+EXTRA_MOUNTS += -v $(PWD)/local_collection/transformed:/pipeline/transformed
+endif
 
 ifdef ($(LOCAL_SPECIFICATION_PATH),)
 EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
@@ -36,7 +47,7 @@ $(info    EXTRA_MOUNTS is $(EXTRA_MOUNTS))
 DOCKER_TAG=latest
 ECR_URL=public.ecr.aws/l6z6v3j6/
 
-COLLECTION_DIR=/pipeline/collection/
+EXTRA_DL_ARGS += --specification-dir /collection/specification
 
 /pipeline/collection/resource.csv:
 
@@ -50,7 +61,7 @@ digital-land = docker run -t \
 	$(EXTRA_MOUNTS) \
 	$(ECR_URL)digital-land-python:$(DOCKER_TAG) \
 	digital-land \
-	--specification-dir /collection/specification
+	$(EXTRA_DL_ARGS)
 
 docker-pull::
 ifndef ($(DISABLE_DOCKER_PULL),)

--- a/makerules.mk
+++ b/makerules.mk
@@ -1,5 +1,6 @@
 SOURCE_URL=https://raw.githubusercontent.com/digital-land/
 
+include makerules/docker.mk
 # deduce the repository
 ifeq ($(REPOSITORY),)
 REPOSITORY=$(shell basename -s .git `git config --get remote.origin.url`)
@@ -58,7 +59,7 @@ second-pass::
 	@:
 
 # initialise
-ifeq (,$(wildcard /.dockerenv ))
+ifeq ($(DOCKERISED),0)
 init::
 	pip install --upgrade pip
 ifneq (,$(wildcard requirements.txt))

--- a/pipeline.mk
+++ b/pipeline.mk
@@ -109,7 +109,7 @@ fetch-transformed-s3::
 	aws s3 sync s3://collection-dataset/$(REPOSITORY)/$(TRANSFORMED_DIR) $(TRANSFORMED_DIR) --no-progress
 	aws s3 sync s3://collection-dataset/$(REPOSITORY)/$(DATASET_DIR) $(DATASET_DIR) --no-progress
 
-# These will run as usual unless we're in a dockerised environment and DEVELOPMENT isn't explicitly set to 1 i.e if DEVELOPMENT != 1 or DOCKERISED != 1
+# These will run as usual if DEVELOPMENT isn't explicitly set to 1
 ifeq ($(DEVELOPMENT),0)
 commit-dataset::
 	mkdir -p $(DATASET_DIRS)

--- a/render.mk
+++ b/render.mk
@@ -33,54 +33,7 @@ ifeq ($(VIEW_MODEL),)
 VIEW_MODEL=$(DATASET_DIR)view_model.sqlite3
 endif
 
-ifndef ($(DOCKERISED),)
-	DOCKERISED = 0
-	DEVELOPMENT = 0
-else
-	# Run in development mode by default for now
-	ifndef ($(DEVELOPMENT),)
-		DEVELOPMENT = 1
-	endif
-endif
-
-EXTRA_MOUNTS :=
-ifeq ($(and $(DOCKERISED),$(DEVELOPMENT)))
-	EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
-
-	ifdef ($(LOCAL_SPECIFICATION_PATH),)
-		EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
-	else ifeq ($(LOCAL_SPECIFICATION),1)
-		EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
-	endif
-	ifdef ($(LOCAL_DL_PYTHON_PATH),)
-		EXTRA_MOUNTS += -v $(LOCAL_DL_PYTHON_PATH):/Src
-	else ifeq ($(LOCAL_DL_PYTHON),1)
-		EXTRA_MOUNTS += -v $(PWD)/../digital-land-python:/src
-	endif
-endif
-
-DOCKER_TAG=latest
-ECR_URL=public.ecr.aws/l6z6v3j6/
-
-digital-land = docker run -t \
-	-u $(shell id -u) \
-	-v $(PWD):/pipeline \
-	$(EXTRA_MOUNTS) \
-	$(ECR_URL)digital-land-python:$(DOCKER_TAG) \
-	digital-land \
-	--specification-dir /collection/specification
-
-docker-pull::
-ifndef ($(DISABLE_DOCKER_PULL),)
-	docker pull $(ECR_URL)digital-land-python:$(DOCKER_TAG)
-endif
-
-init:: docker-pull
-else
-digital-land = digital-land
-endif
-
-
+include makerules/docker.mk
 
 TEMPLATE_FILES=$(wildcard templates/*)
 

--- a/render.mk
+++ b/render.mk
@@ -33,22 +33,30 @@ ifeq ($(VIEW_MODEL),)
 VIEW_MODEL=$(DATASET_DIR)view_model.sqlite3
 endif
 
-ifeq ($(DOCKERISED),1)
-EXTRA_MOUNTS :=
-# Run in development mode by default for now
-ifneq ($(DEVELOPMENT),0)
-EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
+ifndef ($(DOCKERISED),)
+	DOCKERISED = 0
+	DEVELOPMENT = 0
+else
+	# Run in development mode by default for now
+	ifndef ($(DEVELOPMENT),)
+		DEVELOPMENT = 1
+	endif
+endif
 
-ifdef ($(LOCAL_SPECIFICATION_PATH),)
-	EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
-else ifeq ($(LOCAL_SPECIFICATION),1)
-	EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
-endif
-ifdef ($(LOCAL_DL_PYTHON_PATH),)
-	EXTRA_MOUNTS += -v $(LOCAL_DL_PYTHON_PATH):/Src
-else ifeq ($(LOCAL_DL_PYTHON),1)
-	EXTRA_MOUNTS += -v $(PWD)/../digital-land-python:/src
-endif
+EXTRA_MOUNTS :=
+ifeq ($(and $(DOCKERISED),$(DEVELOPMENT)))
+	EXTRA_MOUNTS += -v $(PWD)/local_collection:/data --workdir /data
+
+	ifdef ($(LOCAL_SPECIFICATION_PATH),)
+		EXTRA_MOUNTS += -v $(LOCAL_SPECIFICATION_PATH)/specification:/collection/specification
+	else ifeq ($(LOCAL_SPECIFICATION),1)
+		EXTRA_MOUNTS += -v $(PWD)/../specification/specificaiton:/collection/specification
+	endif
+	ifdef ($(LOCAL_DL_PYTHON_PATH),)
+		EXTRA_MOUNTS += -v $(LOCAL_DL_PYTHON_PATH):/Src
+	else ifeq ($(LOCAL_DL_PYTHON),1)
+		EXTRA_MOUNTS += -v $(PWD)/../digital-land-python:/src
+	endif
 endif
 
 DOCKER_TAG=latest


### PR DESCRIPTION
This is an idea on how to build on the changes made in https://github.com/digital-land/makerules/pull/5 to provision make option to run arbitrary pipeline commands in docker

TODO
* [ ] Fix error when running `make DOCKERISED=1 collect`: `make: *** No rule to make target '/pipeline/collection/source.csv', needed by 'collect'.  Stop.`
