### PR TITLE
Change S3 push targets to point at gov.uk PaaS production S3 Buckets (DON'T MERGE UNTIL DAY BEFORE GOV.UK PAAS GO-LIVE) (UNTESTED)

### DIFF
--- a/github-workflows/run.yml
+++ b/github-workflows/run.yml
@@ -27,12 +27,12 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: Configure AWS Credentials
+    - name: Configure AWS Credentials For Collection Bucket
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{secrets.AWS_S3_ACCESS_KEY_ID}}
-        aws-secret-access-key: ${{secrets.AWS_S3_SECRET_ACCESS_KEY}}
-        aws-region: eu-west-2
+        aws-access-key-id: ${{secrets.PRODUCTION_PAAS_COLLECTION_BUCKET_SERVICE_KEY_AWS_ACCESS_KEY_ID}}
+        aws-secret-access-key: ${{secrets.PRODUCTION_PAAS_COLLECTION_BUCKET_SERVICE_KEY_AWS_SECRET_ACCESS_KEY}}
+        aws-region: ${{secrets.PRODUCTION_PAAS_COLLECTION_BUCKET_SERVICE_KEY_AWS_REGION}}
 
     - name: Configure git
       run: |
@@ -77,3 +77,12 @@ jobs:
     - name: Save datasets to S3
       run: make save-dataset
 
+    - name: Configure AWS Credentials For Hoisted Bucket
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{secrets.PRODUCTION_PAAS_HOISTED_BUCKET_SERVICE_KEY_AWS_ACCESS_KEY_ID}}
+        aws-secret-access-key: ${{secrets.PRODUCTION_PAAS_HOISTED_BUCKET_SERVICE_KEY_AWS_SECRET_ACCESS_KEY}}
+        aws-region: ${{secrets.PRODUCTION_PAAS_HOISTED_BUCKET_SERVICE_KEY_AWS_REGION}}
+
+    - name: Save hoisted files to S3
+      run: make save-hoisted

--- a/github-workflows/run.yml
+++ b/github-workflows/run.yml
@@ -1,0 +1,79 @@
+name: Run collection
+on:
+  schedule:
+  - cron: 0 0 * * *
+  workflow_dispatch: null
+env:
+  DLB_BOT_EMAIL: ${{ secrets.DLB_BOT_EMAIL }}
+  DLB_BOT_TOKEN: ${{ secrets.DLB_BOT_TOKEN }}
+  DLB_BOT_USERNAME: ${{ secrets.DLB_BOT_USERNAME }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Free up disk space
+      run: |
+        df -h
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        echo
+        df -h
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{secrets.AWS_S3_ACCESS_KEY_ID}}
+        aws-secret-access-key: ${{secrets.AWS_S3_SECRET_ACCESS_KEY}}
+        aws-region: eu-west-2
+
+    - name: Configure git
+      run: |
+        git config user.email "${DLB_BOT_EMAIL}"
+        git config user.name "${DLB_BOT_USERNAME}"
+        git remote set-url origin https://${DLB_BOT_USERNAME}:${DLB_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+        git checkout ${GITHUB_REF##*/}
+
+    - name: Update makerules
+      run: make makerules
+
+    - name: Commit updated makerules
+      run: make commit-makerules
+
+    - name: Install dependencies
+      run: make init
+
+    - name: Run the collector
+      run: make collect
+
+    - name: Commit collection logs
+      run: make commit-collection
+
+    - name: Save collected resources to S3
+      run: make save-resources
+
+    - name: Build the collection database
+      run: make collection
+
+    - name: Push collection database to S3
+      run: make save-collection
+
+    - name: transform collected files
+      run: make transformed
+
+    - name: Save transformed files to S3
+      run: make save-transformed
+
+    - name: Build datasets from the transformed files
+      run: make dataset
+
+    - name: Save datasets to S3
+      run: make save-dataset
+

--- a/pipeline.mk
+++ b/pipeline.mk
@@ -109,8 +109,18 @@ init::
 	@mkdir -p $(CACHE_DIR)
 	curl -qfs "https://raw.githubusercontent.com/digital-land/organisation-dataset/main/collection/organisation.csv" > $(CACHE_DIR)organisation.csv
 
-makerules::
+makerules:: update-github-workflow-for-next-run
 	curl -qfsL '$(SOURCE_URL)/makerules/main/pipeline.mk' > makerules/pipeline.mk
+
+update-github-workflow-for-next-run::
+ifeq ($(GITHUB_REPOSITORY),)
+$(error $$GITHUB_REPOSITORY not set)
+endif
+ifeq $(collection,$(word 2,$(subst -, ,$(GITHUB_REPOSITORY),)))
+	curl -qfsL '$(SOURCE_URL)/makerules/github-workflows/run.yml' > .github/workflows/run.yml
+else
+	echo "Not updating .github/workflows/run.yml from makerules repo, as $(GITHUB_REPOSITORY) is not a collection repository"
+endif
 
 save-transformed::
 	aws s3 sync $(TRANSFORMED_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(TRANSFORMED_DIR) --no-progress

--- a/pipeline.mk
+++ b/pipeline.mk
@@ -130,6 +130,8 @@ save-transformed::
 
 save-dataset::
 	aws s3 sync $(DATASET_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(DATASET_DIR) --no-progress
+
+save-hoisted::
 	@mkdir -p $(HOISTED_DIR)
 	aws s3 sync $(HOISTED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/ --no-progress
 


### PR DESCRIPTION
This will also require the Github Organization Secrets `COLLECTION_DATASET_BUCKET_NAME` and `HOISTED_DATASET_BUCKET_NAME` to be changed to point to the gov.uk PaaS collection and hoisted buckets respectively. These are managed by terraform, so a seperate PR to `digital-land-infrastructure` will be created to modify these values based on the credentials returned by cloudfoundry

It's important to note that these changes to the workflow won't take effect in the workflow execution in which they are pulled into the repo, only the next execution. Therefore the production go-live needs to be coordinated such that this PR is merged one day before the production go-live date.