### PR TITLE
update pipeline so expectations are read from different location

### DIFF
--- a/pipeline.mk
+++ b/pipeline.mk
@@ -76,11 +76,9 @@ define build-dataset =
 	mkdir -p $(FLATTENED_DIR)
 	time digital-land --dataset $(notdir $(basename $@)) dataset-entries-flattened $@ $(FLATTENED_DIR)
 	md5sum $@ $(basename $@).sqlite3
-	csvstack $(ISSUE_DIR)$(notdir $(basename $@))/*.csv > $(basename $@)-issue.csv
-	mkdir -p $(EXPECTATION_DIR)yamls/dataset_acceptance/
-	mkdir -p $(EXPECTATION_DIR)results/dataset_acceptance/$(notdir $(basename $@))
-	-curl -qsfL 'https://raw.githubusercontent.com/digital-land/expectations-config/main/dataset_acceptance/$(notdir $(basename $@)).yaml' > $(EXPECTATION_DIR)yamls/dataset_acceptance/$(notdir $(basename $@)).yaml
-	time digital-land expectations --results-path "$(EXPECTATION_DIR)results/dataset_acceptance/$(notdir $(basename $@))" --sqlite-dataset-path "$(basename $@).sqlite3" --data-quality-yaml "$(EXPECTATION_DIR)yamls/dataset_acceptance/$(notdir $(basename $@)).yaml"
+	csvstack $(wildcard $(ISSUE_DIR)/$(notdir $(basename $@))/*.csv) > $(basename $@)-issue.csv
+	mkdir -p $(EXPECTATION_DIR)
+	time digital-land expectations --results-path "$(EXPECTATION_DIR)$(notdir $(basename $@)).csv" --sqlite-dataset-path "$(basename $@).sqlite3" --data-quality-yaml "$(EXPECTATION_DIR)$(notdir $(basename $@)).yaml"
 endef
 
 collection::
@@ -139,8 +137,8 @@ else
 endif
 
 save-expectations::
-	@mkdir -p $(EXPECTATION_DIR)results/
-	aws s3 sync $(EXPECTATION_DIR)results/ s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(EXPECTATION_DIR)
+	@mkdir -p $(EXPECTATION_DIR)
+	aws s3 sync $(EXPECTATION_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(EXPECTATION_DIR) --exclude "*" --include "*.csv"
 
 # convert an individual resource
 # .. this assumes conversion is the same for every dataset, but it may not be soon

--- a/pipeline.mk
+++ b/pipeline.mk
@@ -76,7 +76,7 @@ define build-dataset =
 	mkdir -p $(FLATTENED_DIR)
 	time digital-land --dataset $(notdir $(basename $@)) dataset-entries-flattened $@ $(FLATTENED_DIR)
 	md5sum $@ $(basename $@).sqlite3
-	csvstack $(wildcard $(ISSUE_DIR)/$(notdir $(basename $@))/*.csv) > $(basename $@)-issue.csv
+	csvstack $(ISSUE_DIR)$(notdir $(basename $@))/*.csv > $(basename $@)-issue.csv
 	mkdir -p $(EXPECTATION_DIR)
 	time digital-land expectations --results-path "$(EXPECTATION_DIR)$(notdir $(basename $@)).csv" --sqlite-dataset-path "$(basename $@).sqlite3" --data-quality-yaml "$(EXPECTATION_DIR)$(notdir $(basename $@)).yaml"
 endef


### PR DESCRIPTION
What?
Update pipeline.mk to reflect change in approach to running expectations. yaml files expect to be stored in expectations folder as expectations/dataset-name.yaml. pipline then uses this to create results in expectations/dataset-name.csv

saving to s3 command updated to reflect this

Why?
stop hiding output in several folders and output is in csv format