### PR TITLE
Support centralised configuration

### DIFF
--- a/collection.mk
+++ b/collection.mk
@@ -4,6 +4,10 @@
 	commit-collection\
 	clobber-today
 
+ifeq ($(COLLECTION_CONFIG_URL),)
+COLLECTION_CONFIG_URL=$(CONFIG_URL)collection/$(COLLECTION_NAME)/
+endif
+
 ifeq ($(COLLECTION_DIR),)
 COLLECTION_DIR=collection/
 endif
@@ -20,6 +24,14 @@ endif
 # data sources
 SOURCE_CSV=$(COLLECTION_DIR)source.csv
 ENDPOINT_CSV=$(COLLECTION_DIR)endpoint.csv
+OLD_RESOURCE_CSV=$(COLLECTION_DIR)old-resource.csv
+
+ifeq ($(COLLECTION_CONFIG_FILES),)
+COLLECTION_CONFIG_FILES=\
+	$(SOURCE_CSV)\
+	$(ENDPOINT_CSV)\
+	$(OLD_RESOURCE_CSV)
+endif
 
 # collection log
 LOG_DIR=$(COLLECTION_DIR)log/
@@ -34,7 +46,7 @@ first-pass:: collect
 
 second-pass:: collection
 
-collect:: $(SOURCE_CSV) $(ENDPOINT_CSV)
+collect:: $(COLLECTION_CONFIG_FILES)
 	@mkdir -p $(RESOURCE_DIR)
 	digital-land collect $(ENDPOINT_CSV)
 
@@ -69,3 +81,12 @@ endif
 collection/resource/%:
 	@mkdir -p collection/resource/
 	curl -qfsL '$(DATASTORE_URL)$(REPOSITORY)/$(RESOURCE_DIR)$(notdir $@)' > $@
+
+collection/%.csv:
+	@mkdir -p $(COLLECTION_DIR)
+	curl -qfsL '$(COLLECTION_CONFIG_URL)$(notdir $@)' > $@
+
+config:: $(COLLECTION_CONFIG_FILES)
+
+clean::
+	rm -f $(COLLECTION_CONFIG_FILES)

--- a/makerules.mk
+++ b/makerules.mk
@@ -1,5 +1,3 @@
-SOURCE_URL=https://raw.githubusercontent.com/digital-land/
-
 # deduce the repository
 ifeq ($(REPOSITORY),)
 REPOSITORY=$(shell basename -s .git `git config --get remote.origin.url`)
@@ -8,19 +6,37 @@ endif
 ifeq ($(ENVIRONMENT),)
 ENVIRONMENT=production
 endif
+
+ifeq ($(SOURCE_URL),)
+SOURCE_URL=https://raw.githubusercontent.com/digital-land/
+endif
+
+ifeq ($(CONFIG_URL),)
+CONFIG_URL=https://raw.githubusercontent.com/digital-land/config/main/
+endif
+
+ifeq ($(COLLECTION_NAME),)
+COLLECTION_NAME=$(shell echo "$(REPOSITORY)"|sed 's/-collection$$//')
+endif
+
 ifeq ($(COLLECTION_DATASET_BUCKET_NAME),)
 COLLECTION_DATASET_BUCKET_NAME=digital-land-$(ENVIRONMENT)-collection-dataset
 endif
+
 ifeq ($(HOISTED_COLLECTION_DATASET_BUCKET_NAME),)
 HOISTED_COLLECTION_DATASET_BUCKET_NAME=digital-land-$(ENVIRONMENT)-collection-dataset-hoisted
 endif
+
 define dataset_url
 'https://$(COLLECTION_DATASET_BUCKET_NAME).s3.eu-west-2.amazonaws.com/$(2)-collection/dataset/$(1).sqlite3'
 endef
 
+
+
 .PHONY: \
 	makerules\
 	specification\
+	config\
 	init\
 	first-pass\
 	second-pass\
@@ -118,6 +134,10 @@ specification::
 
 init::	specification
 endif
+
+init:: config
+
+config::;
 
 commit-makerules::
 	git add makerules

--- a/pipeline.mk
+++ b/pipeline.mk
@@ -4,11 +4,19 @@
 	commit-dataset
 
 # data sources
-# collected resources
+ifeq ($(PIPELINE_CONFIG_URL),)
+PIPELINE_CONFIG_URL=$(CONFIG_URL)pipeline/$(COLLECTION_NAME)/
+endif
+
 ifeq ($(COLLECTION_DIR),)
 COLLECTION_DIR=collection/
 endif
 
+ifeq ($(PIPELINE_DIR),)
+PIPELINE_DIR=pipeline/
+endif
+
+# collected resources
 ifeq ($(RESOURCE_DIR),)
 RESOURCE_DIR=$(COLLECTION_DIR)resource/
 endif
@@ -61,6 +69,21 @@ endif
 
 ifeq ($(EXPECTATION_DIR),)
 EXPECTATION_DIR = expectations/
+endif
+
+ifeq ($(PIPELINE_CONFIG_FILES),)
+PIPELINE_CONFIG_FILES=\
+	$(PIPELINE_DIR)column.csv\
+	$(PIPELINE_DIR)combine.csv\
+	$(PIPELINE_DIR)concat.csv\
+	$(PIPELINE_DIR)convert.csv\
+	$(PIPELINE_DIR)default.csv\
+	$(PIPELINE_DIR)default-value.csv\
+	$(PIPELINE_DIR)filter.csv\
+	$(PIPELINE_DIR)lookup.csv\
+	$(PIPELINE_DIR)patch.csv\
+	$(PIPELINE_DIR)skip.csv\
+	$(PIPELINE_DIR)transform.csv
 endif
 
 define run-pipeline
@@ -157,3 +180,12 @@ datasette:	metadata.json
 	--setting sql_time_limit_ms 5000 \
 	--load-extension $(SPATIALITE_EXTENSION) \
 	--metadata metadata.json
+
+$(PIPELINE_DIR)%.csv:
+	@mkdir -p $(PIPELINE_DIR)
+	curl -qfsL '$(PIPELINE_CONFIG_URL)$(notdir $@)' > $@
+
+config:: $(PIPELINE_CONFIG_FILES)
+
+clean::
+	rm -f $(PIPELINE_CONFIG_FILES)


### PR DESCRIPTION
Download collection and pipeline CSV files from the central config repository if they are missing.

After testing we can remove collection/*csv and pipline/*csv from the -collection repositories so the copies in the config repository become the canonical source.