### PR TITLE
Test if libsqlite3-mod-spatialite is already installed

### DIFF
--- a/pipeline.mk
+++ b/pipeline.mk
@@ -126,7 +126,7 @@ endif
 endif
 	pyproj sync --file uk_os_OSTN15_NTv2_OSGBtoETRS.tif -v
 ifeq ($(UNAME),Linux)
-	sudo apt-get install libsqlite3-mod-spatialite
+	dpkg-query -W libsqlite3-mod-spatialite >/dev/null 2>&1 || sudo apt-get install libsqlite3-mod-spatialite
 endif
 
 clobber::


### PR DESCRIPTION
Test if sqlite-package-installed is missing before installing it. 
Helpful to stop asking for the root password for make init on a development machine.