### PR TITLE
Adds download for la geometry in pipeline.mk

### DIFF
--- a/makerules.mk
+++ b/makerules.mk
@@ -144,6 +144,13 @@ $(CACHE_DIR)organisation.csv:
 	@mkdir -p $(CACHE_DIR)
 	curl -qfs "https://raw.githubusercontent.com/digital-land/organisation-dataset/main/collection/organisation.csv" > $(CACHE_DIR)organisation.csv
 
+
+# download la geometry
+$(CACHE_DIR)la_geometry.geojson:
+	@mkdir -p $(CACHE_DIR)
+	curl -qfs "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/Local_Authority_Districts_May_2023_UK_BFE_V2/FeatureServer/0/query?where=1%3D1&outFields=*&outSR=4326&f=json" > $(CACHE_DIR)la_geometry.geojson
+
+
 init:: config
 
 config::;

--- a/pipeline.mk
+++ b/pipeline.mk
@@ -139,6 +139,9 @@ clean::
 # local copy of the organisation dataset
 init::	$(CACHE_DIR)organisation.csv
 
+# get local authority geometry data
+init:: $(CACHE_DIR)la_geometry.geojson
+
 makerules::
 	curl -qfsL '$(SOURCE_URL)/makerules/main/pipeline.mk' > makerules/pipeline.mk
 


### PR DESCRIPTION
This adds a make init rule to download local authority geometry, for use in the boundary check that occurs in the harmonise phase of the pipeline (see [this PR](https://github.com/digital-land/digital-land-python/pull/145))