### PR TITLE
Content disposition of attachment for flattened dataset files

### DIFF
--- a/pipeline.mk
+++ b/pipeline.mk
@@ -158,7 +158,7 @@ save-dataset::
 ifeq ($(HOISTED_COLLECTION_DATASET_BUCKET_NAME),digital-land-$(ENVIRONMENT)-collection-dataset-hoisted)
 	aws s3 sync $(FLATTENED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/data/ --no-progress
 else
-	aws s3 sync $(FLATTENED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/dataset/ --no-progress
+	aws s3 sync $(FLATTENED_DIR) s3://$(HOISTED_COLLECTION_DATASET_BUCKET_NAME)/dataset/ --no-progress --content-disposition attachment
 endif
 
 save-expectations::


### PR DESCRIPTION
Added content disposition option to s3 sync for the flattened dataset files.  This addresses a problem reported by users around downloading files from the Datasets page of the Platform main website:

https://trello.com/c/kI3Jd0nH/3399-downloading-of-large-geojson-files-from-platform?filter=label:Infrastructure,label:DevOps