### PR TITLE
fixes operational issue log download in make init

### DIFF
--- a/pipeline.mk
+++ b/pipeline.mk
@@ -159,15 +159,17 @@ clean::
 # local copy of the organisation dataset
 # Download historic operational issue log data for relevant datasets
 init::	$(CACHE_DIR)organisation.csv
+	@mkdir -p $(OPERATIONAL_ISSUE_DIR)
 	@datasets=$$(awk -F , '$$2 == "$(COLLECTION_NAME)" {print $$4}' specification/dataset.csv); \
 	for dataset in $$datasets; do \
+		mkdir -p $(OPERATIONAL_ISSUE_DIR)$$dataset; \
 		url="$(DATASTORE_URL)$(OPERATIONAL_ISSUE_DIR)$$dataset/operational-issue.csv"; \
 		echo "Downloading operational issue log for $$dataset at url $$url";\
 		status_code=$$(curl --write-out "%{http_code}" --silent --output /dev/null "$$url"); \
 		if [ "$$status_code" -eq 200 ]; then \
 			echo "Downloading file..."; \
-			curl --silent --output "$(OPERATIONAL_ISSUE_DIR)/$$dataset/operational-issue.csv" "$$url"; \
-			echo "Log downloaded to $(OPERATIONAL_ISSUE_DIR)/$$dataset/operational-issue.csv"; \
+			curl --silent --output "$(OPERATIONAL_ISSUE_DIR)$$dataset/operational-issue.csv" "$$url"; \
+			echo "Log downloaded to $(OPERATIONAL_ISSUE_DIR)$$dataset/operational-issue.csv"; \
 		else \
 			echo "File not found at $$url"; \
 		fi; \


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes the operational-issue.csv download feature that happens during make init in a collection. Previously there was no way to test this until we had a file hosted on the s3 bucket

## Related Tickets & Documents

https://trello.com/c/WqmRhmvR/3527-save-combined-operationalissue-csv-per-dataset-in-digital-land-python

## QA Instructions, Screenshots, Recordings

Replace the makerules/pipeline.mk in the article-4-direction collection and run make init. It should correctly download the existing 