### PR TITLE
Saving log.csv and resource.csv to S3 if incremental loading enabled

### DIFF
--- a/collection.mk
+++ b/collection.mk
@@ -99,6 +99,11 @@ save-resources::
 save-logs::
 	aws s3 sync $(COLLECTION_DIR)log s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR)log --no-progress
 
+# if incremental loading is enabled than we still need to copy over the log and resource files
+save-collection-log-resource::
+	aws s3 cp $(COLLECTION_DIR)log.csv s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR) --no-progress
+	aws s3 cp $(COLLECTION_DIR)resource.csv s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR) --no-progress
+
 save-collection::
 	aws s3 cp $(COLLECTION_DIR)log.csv s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR) --no-progress
 	aws s3 cp $(COLLECTION_DIR)resource.csv s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR) --no-progress


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

At present if incremental loading is enabled then the updated log.csv and resource.csv are not sent to S3 (so can be out of date). This corrects that behaviour/

## Related Tickets & Documents
[#326](https://github.com/orgs/digital-land/projects/9/views/14?pane=issue&itemId=95524485&issue=digital-land%7Cdigital-land-python%7C326)

