### PR TITLE
Determine new resources

### DIFF
--- a/collection.mk
+++ b/collection.mk
@@ -100,7 +100,7 @@ load-logs::
 	aws s3 sync s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR)log $(COLLECTION_DIR)log --no-progress
 
 save-resources::
-ifeq ($(INCREMENTAL_LOADING_LOADING_OVERRIDE),True)
+ifeq ($(INCREMENTAL_LOADING_OVERRIDE),True)
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --no-progress
 else
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --size-only --no-progress

--- a/collection.mk
+++ b/collection.mk
@@ -100,7 +100,11 @@ load-logs::
 	aws s3 sync s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR)log $(COLLECTION_DIR)log --no-progress
 
 save-resources::
+ifeq ($(INCREMENTAL_LOADING_LOADING_OVERRIDE),True)
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --no-progress
+else
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --size-only --no-progress
+endif
 
 save-logs::
 	aws s3 sync $(COLLECTION_DIR)log s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR)log --no-progress

--- a/makerules.mk
+++ b/makerules.mk
@@ -12,7 +12,7 @@ SOURCE_URL=https://raw.githubusercontent.com/digital-land/
 endif
 
 ifeq ($(MAKERULES_URL),)
-MAKERULES_URL=$(SOURCE_URL)makerules/main/
+MAKERULES_URL=$(SOURCE_URL)makerules/determine-new-resources/
 endif
 
 ifeq ($(DATASTORE_URL),)

--- a/makerules.mk
+++ b/makerules.mk
@@ -12,7 +12,7 @@ SOURCE_URL=https://raw.githubusercontent.com/digital-land/
 endif
 
 ifeq ($(MAKERULES_URL),)
-MAKERULES_URL=$(SOURCE_URL)makerules/determine-new-resources/
+MAKERULES_URL=$(SOURCE_URL)makerules/main/
 endif
 
 ifeq ($(DATASTORE_URL),)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a flag to the 'save-resources' aws sync command called '--size-only'. This means the command will only upload files of the same name that already exist on s3 if the file sizes are different. In the case of resources, we would always expect the resources with the same hash and file size to be the same.
This behaviour can be disabled by using the incremental loading override button on airflow 

## Related Tickets & Documents

- Ticket Link
- Related Issue #79 
- Closes #79 

## QA Instructions, Screenshots, Recordings

With incremental loading off:
![image](https://github.com/user-attachments/assets/2fa253b1-349c-435d-9728-9443f36a35ea)
Resource files are uploaded


With incremental loading on:
![image](https://github.com/user-attachments/assets/3e2453a5-1739-4912-8c22-516d2cf6045d)
Note how there are no files uploaded after `aws sync collection/resource`

