### PR TITLE
Detect new resources rule

### DIFF
--- a/collection.mk
+++ b/collection.mk
@@ -102,7 +102,7 @@ load-logs::
 new-resources-list::
 	echo Determine new resources that have been downloaded
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun --size-only
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun --size-only | grep -oP 'resource/\K[a-f0-9]+' > new_resources.txt
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun --size-only | grep -oP 'resource/\K[a-f0-9]+' > new_resources.txt || true
 	cat new_resources.txt
 
 save-resources::

--- a/collection.mk
+++ b/collection.mk
@@ -99,6 +99,14 @@ load-resources::
 load-logs::
 	aws s3 sync s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR)log $(COLLECTION_DIR)log --no-progress
 
+new-resources-list::
+	echo Determine new resources that have been downloaded
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun > new_resources
+	cat new_resources
+
+	exit 0
+
 save-resources::
 ifeq ($(INCREMENTAL_LOADING_OVERRIDE),True)
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --no-progress

--- a/collection.mk
+++ b/collection.mk
@@ -101,7 +101,7 @@ load-logs::
 
 new-resources-list::
 	echo Determine new resources that have been downloaded
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+'
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+' > new_resources.txt
 	cat new_resources.txt
 

--- a/collection.mk
+++ b/collection.mk
@@ -101,8 +101,8 @@ load-logs::
 
 new-resources-list::
 	echo Determine new resources that have been downloaded
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | awk 'match($3,"^(s3://[^/]+/)(.*)",a) {print a[2]}'
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | awk 'match($3,"^(s3://[^/]+/)(.*)",a) {print a[2]}' > new_resources
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+'
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+' > new_resources
 	cat new_resources
 
 	exit 0

--- a/collection.mk
+++ b/collection.mk
@@ -103,7 +103,7 @@ new-resources-list::
 	echo Determine new resources that have been downloaded
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+'
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+' > new_resources.txt
-	cat new_resources
+	cat new_resources.txt
 
 save-resources::
 ifeq ($(INCREMENTAL_LOADING_OVERRIDE),True)

--- a/collection.mk
+++ b/collection.mk
@@ -100,8 +100,8 @@ load-logs::
 	aws s3 sync s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR)log $(COLLECTION_DIR)log --no-progress
 
 detect-new-resources::
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun --size-only | grep -oP 'resource/\K[a-f0-9]+' > new_resources.txt || true
-
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun --size-only | { grep -oP 'resource/\K[a-f0-9]+' || true; } > new_resources.txt
+	
 save-resources::
 ifeq ($(INCREMENTAL_LOADING_OVERRIDE),True)
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --no-progress

--- a/collection.mk
+++ b/collection.mk
@@ -102,10 +102,8 @@ load-logs::
 new-resources-list::
 	echo Determine new resources that have been downloaded
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+'
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+' > new_resources
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+' > new_resources.txt
 	cat new_resources
-
-	exit 0
 
 save-resources::
 ifeq ($(INCREMENTAL_LOADING_OVERRIDE),True)

--- a/collection.mk
+++ b/collection.mk
@@ -101,8 +101,8 @@ load-logs::
 
 new-resources-list::
 	echo Determine new resources that have been downloaded
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | grep -oP 'resource/\K[a-f0-9]+' > new_resources.txt
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun --size-only
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun --size-only | grep -oP 'resource/\K[a-f0-9]+' > new_resources.txt
 	cat new_resources.txt
 
 save-resources::

--- a/collection.mk
+++ b/collection.mk
@@ -99,11 +99,8 @@ load-resources::
 load-logs::
 	aws s3 sync s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(COLLECTION_DIR)log $(COLLECTION_DIR)log --no-progress
 
-new-resources-list::
-	echo Determine new resources that have been downloaded
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun --size-only
+detect-new-resources::
 	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun --size-only | grep -oP 'resource/\K[a-f0-9]+' > new_resources.txt || true
-	cat new_resources.txt
 
 save-resources::
 ifeq ($(INCREMENTAL_LOADING_OVERRIDE),True)

--- a/collection.mk
+++ b/collection.mk
@@ -101,8 +101,8 @@ load-logs::
 
 new-resources-list::
 	echo Determine new resources that have been downloaded
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun
-	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun > new_resources
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | awk 'match($3,"^(s3://[^/]+/)(.*)",a) {print a[2]}'
+	aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun | awk 'match($3,"^(s3://[^/]+/)(.*)",a) {print a[2]}' > new_resources
 	cat new_resources
 
 	exit 0

--- a/makerules.mk
+++ b/makerules.mk
@@ -12,7 +12,7 @@ SOURCE_URL=https://raw.githubusercontent.com/digital-land/
 endif
 
 ifeq ($(MAKERULES_URL),)
-MAKERULES_URL=$(SOURCE_URL)makerules/new-resources-list/
+MAKERULES_URL=$(SOURCE_URL)makerules/main/
 endif
 
 ifeq ($(DATASTORE_URL),)

--- a/makerules.mk
+++ b/makerules.mk
@@ -12,7 +12,7 @@ SOURCE_URL=https://raw.githubusercontent.com/digital-land/
 endif
 
 ifeq ($(MAKERULES_URL),)
-MAKERULES_URL=$(SOURCE_URL)makerules/main/
+MAKERULES_URL=$(SOURCE_URL)makerules/new-resources-list/
 endif
 
 ifeq ($(DATASTORE_URL),)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a new rule that can be used to detect whether new resources have been downloaded.
It does a dryrun of a --size-only aws sync command on the resource folder. The --size-only flag means it only uploads files of the same name if the sizes are different (we use this already for only uploading new resources), and the dryrun option means it doesn't actually do any uploading but outputs what it would upload.
We take this output and store it in a text file `new_resources.txt`


## Related Tickets & Documents

- Ticket Link https://github.com/orgs/digital-land/projects/9/views/3?pane=issue&itemId=93866679&issue=digital-land%7Ctechnical-documentation%7C234
- Related Issue #
- Closes #