### PR TITLE
feat: get specifictation from s3

### DIFF
--- a/makerules.mk
+++ b/makerules.mk
@@ -23,6 +23,10 @@ ifeq ($(CONFIG_URL),)
 CONFIG_URL=$(DATASTORE_URL)config/
 endif
 
+ifeq ($(SPECIFICATION_URL),)
+SPECIFICATION_URL=$(DATASTORE_URL)specification/
+endif
+
 ifeq ($(COLLECTION_NAME),)
 COLLECTION_NAME=$(shell echo "$(REPOSITORY)"|sed 's/-collection$$//')
 endif
@@ -122,26 +126,20 @@ makerules::
 	curl -qfsL '$(MAKERULES_URL)makerules.mk' > makerules/makerules.mk
 
 ifeq (,$(wildcard ./makerules/specification.mk))
-# update local copies of specification files
-specification::
-	@mkdir -p specification/
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/attribution.csv' > specification/attribution.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/licence.csv' > specification/licence.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/typology.csv' > specification/typology.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/theme.csv' > specification/theme.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/collection.csv' > specification/collection.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/dataset.csv' > specification/dataset.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/dataset-field.csv' > specification/dataset-field.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/field.csv' > specification/field.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/datatype.csv' > specification/datatype.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/prefix.csv' > specification/prefix.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/provision-rule.csv' > specification/provision-rule.csv
-	# deprecated ..
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/pipeline.csv' > specification/pipeline.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/dataset-schema.csv' > specification/dataset-schema.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/schema.csv' > specification/schema.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/schema-field.csv' > specification/schema-field.csv
+# update local copies of specification files (S3 in AWS, CDN locally — same as organisation.csv)
+SPECIFICATION_CSVS=\
+	attribution licence typology theme collection dataset dataset-field \
+	field datatype prefix provision-rule pipeline dataset-schema schema schema-field
 
+specification:: $(addprefix specification/,$(addsuffix .csv,$(SPECIFICATION_CSVS)))
+
+specification/%.csv:
+	@mkdir -p specification/
+ifneq ($(COLLECTION_DATASET_BUCKET_NAME),)
+	aws s3 cp s3://$(COLLECTION_DATASET_BUCKET_NAME)/specification/$(notdir $@) $@ --no-progress
+else
+	curl -qfsL '$(SPECIFICATION_URL)$(notdir $@)?version=$(shell date +%s)' -o $@
+endif
 
 init::	specification
 endif


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Repoint the makerules `specification` target away from raw.githubusercontent.com:
- In AWS: `aws s3 cp` from `s3://$(COLLECTION_DATASET_BUCKET_NAME)/specification/`
- Local: `curl` from the CDN

Mirrors how config and organisation.csv already work in this file.

## Why
Overnight, many collection/loader tasks hit GitHub too hard above its rate limit on the ~15 unauthenticated spec downloads. `curl --fail` turns the HTTP error into exit 22 with no retry, aborting the whole task — the cause of the sporadic weekend DAG failures.

## follow up will be required after this PR is merged.

This PR only changes the shared makerules `specification` target, so it covers the tasks that fetch the spec **through makerules** (e.g. collection-task, config, build-digital-land-builder-task), which pick it up automatically since they pull makerules from `main` at runtime. It is a partway change, not the whole job.

- I will need to update the `makerules/makerules.mk` in consuming repos (collection-task, build-digital-land-builder-task, config) after merge, so their code version matches the code which is actually run at runtime rather than still showing the old GitHub fetch.

A few repos fetch the specification **independently of this target** and will still download from GitHub until updated in separate follow-up PRs — notably `digital-land-postgres` (`task/load.sh` has its own hardcoded curl block) and `airflow-dags` (`dags/utils.py` fetches `dataset.csv` via `urllib`). Maybe we want to tidy this up. I think we probably want to make this consistent across all the repos otherwise, it will be confusing when say trying to test out a specification change in DEV and the change will apply to some bits of code but not others. I will make a ticket for this tech-debt.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2739)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

## Testing

- **Files CDN endpoint check** — confirmed spec files are live and served at `files.planning.data.gov.uk/specification/<file>.csv` (HTTP 200 for `dataset`, `schema-field`, `prefix`, `provision-rule`).
- **Local CDN-branch test** — with this branch's makerules in a collection-task checkout, ran `make specification` (no bucket var set) → all 15 spec CSVs downloaded from the CDN, all non-empty with expected sizes.
- **Local S3-branch test** — ran `make specification` with `COLLECTION_DATASET_BUCKET_NAME=development-collection-data` (`AWS_PROFILE=dl-platform-dev`) → all 15 pulled via `aws s3 cp` from `s3://development-collection-data/specification/`; file sizes identical to the CDN results, confirming both sources serve the same content.
- **IAM verified** — the collection-task dev task role has bucket-wide S3 access (`s3:GetObject` + `s3:ListBucket` on `arn:aws:s3:::development-collection-data/*`), so the new `specification/` prefix is readable by the running task, not just by local SSO creds.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: hard to do tests for makefiles.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
